### PR TITLE
태그 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    //Query logging
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
     //aws s3 추가
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
@@ -95,6 +98,7 @@ jacocoTestReport {
                             '**/*Application*',
                             '**/common/config/**',
                             '**/common/exception/**',
+                            '**/common/util/p6spy/**'
                     ] + Qdomains)
                 })
         )
@@ -131,6 +135,7 @@ jacocoTestCoverageVerification {
                     '**.*Application*',
                     '**.common.config.**',
                     '**.common.exception.**',
+                    '**.common.util.p6spy.**'
             ] + Qdomains
         }
     }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/common/scroll/Scroll.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/common/scroll/Scroll.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -14,8 +13,8 @@ public class Scroll<T> {
     private Object nextCursor;
     private Object nextSubCursor;
 
-    public <U> Scroll<U> map(Function<? super T, ? extends U> converter) {
-        List<U> list = content.stream().map(converter).collect(Collectors.toList());
+    public <U> Scroll<U> map(Function<? super T, U> converter) {
+        List<U> list = content.stream().map(converter).toList();
         return new Scroll<>(list, nextCursor, nextSubCursor);
     }
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/common/scroll/Scroll.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/common/scroll/Scroll.java
@@ -1,0 +1,21 @@
+package com.koreanbrains.onlinebutlerback.common.scroll;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class Scroll<T> {
+    private List<T> content;
+    private Object nextCursor;
+    private Object nextSubCursor;
+
+    public <U> Scroll<U> map(Function<? super T, ? extends U> converter) {
+        List<U> list = content.stream().map(converter).collect(Collectors.toList());
+        return new Scroll<>(list, nextCursor, nextSubCursor);
+    }
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/common/util/p6spy/P6spyLogMessageFormatConfiguration.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/common/util/p6spy/P6spyLogMessageFormatConfiguration.java
@@ -1,0 +1,14 @@
+package com.koreanbrains.onlinebutlerback.common.util.p6spy;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class P6spyLogMessageFormatConfiguration {
+
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6spySqlFormatConfiguration.class.getName());
+    }
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/common/util/p6spy/P6spySqlFormatConfiguration.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/common/util/p6spy/P6spySqlFormatConfiguration.java
@@ -1,0 +1,33 @@
+package com.koreanbrains.onlinebutlerback.common.util.p6spy;
+
+import com.p6spy.engine.common.P6Util;
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import java.util.Locale;
+
+public class P6spySqlFormatConfiguration implements MessageFormattingStrategy {
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        sql = formatSql(category, sql);
+        return now + "|" + elapsed + "ms|" + category + "|connection " + connectionId + "|" + P6Util.singleLine(prepared) + sql;
+    }
+
+    private String formatSql(String category,String sql) {
+        if(sql ==null || sql.trim().equals("")) return sql;
+
+        // Only format Statement, distinguish DDL And DML
+        if (Category.STATEMENT.getName().equals(category)) {
+            String tmpsql = sql.trim().toLowerCase(Locale.ROOT);
+            if(tmpsql.startsWith("create") || tmpsql.startsWith("alter") || tmpsql.startsWith("comment")) {
+                sql = FormatStyle.DDL.getFormatter().format(sql);
+            }else {
+                sql = FormatStyle.BASIC.getFormatter().format(sql);
+            }
+            sql = "|\nHeFormatSql(P6Spy sql,Hibernate format):"+ sql;
+        }
+
+        return sql;
+    }
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostController.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostController.java
@@ -4,8 +4,11 @@ import com.koreanbrains.onlinebutlerback.common.exception.EntityNotFoundExceptio
 import com.koreanbrains.onlinebutlerback.common.exception.ErrorCode;
 import com.koreanbrains.onlinebutlerback.entity.post.Post;
 import com.koreanbrains.onlinebutlerback.entity.post.PostImage;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
 import com.koreanbrains.onlinebutlerback.repository.post.PostImageRepository;
 import com.koreanbrains.onlinebutlerback.repository.post.PostRepository;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagMappingRepository;
 import com.koreanbrains.onlinebutlerback.service.post.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +25,7 @@ public class PostController {
     private final PostService postService;
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
+    private final TagMappingRepository tagMappingRepository;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -34,8 +38,11 @@ public class PostController {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
         List<PostImage> postImages = postImageRepository.findByPostId(postId);
+        List<Tag> tags = tagMappingRepository.findAllByPost(post).stream()
+                .map(TagMapping::getTag)
+                .toList();
 
-        return new PostGetResponse(post, postImages);
+        return new PostGetResponse(post, postImages, tags);
     }
 
     // TODO : Security 적용

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostController.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostController.java
@@ -2,12 +2,15 @@ package com.koreanbrains.onlinebutlerback.controller.post;
 
 import com.koreanbrains.onlinebutlerback.common.exception.EntityNotFoundException;
 import com.koreanbrains.onlinebutlerback.common.exception.ErrorCode;
+import com.koreanbrains.onlinebutlerback.common.scroll.Scroll;
 import com.koreanbrains.onlinebutlerback.entity.post.Post;
 import com.koreanbrains.onlinebutlerback.entity.post.PostImage;
 import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
 import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
 import com.koreanbrains.onlinebutlerback.repository.post.PostImageRepository;
+import com.koreanbrains.onlinebutlerback.repository.post.PostQueryRepository;
 import com.koreanbrains.onlinebutlerback.repository.post.PostRepository;
+import com.koreanbrains.onlinebutlerback.repository.post.PostScrollDto;
 import com.koreanbrains.onlinebutlerback.repository.tag.TagMappingRepository;
 import com.koreanbrains.onlinebutlerback.service.post.PostService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ public class PostController {
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
     private final TagMappingRepository tagMappingRepository;
+    private final PostQueryRepository postQueryRepository;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -59,5 +63,10 @@ public class PostController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePost(@PathVariable("postId") Long postId) {
         postService.deletePost(postId, 1L);
+    }
+
+    @GetMapping
+    public Scroll<PostScrollDto> scrollPost(@ModelAttribute PostScrollRequest request) {
+        return postQueryRepository.scrollPost(request.cursor(), request.tagName(), request.size());
     }
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostController.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostController.java
@@ -26,7 +26,7 @@ public class PostController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Long createPost(@RequestPart("post") PostCreateRequest request, @RequestPart("images") MultipartFile[] images) {
-        return postService.createPost(request.caption(), images);
+        return postService.createPost(request.caption(), images, request.tags());
     }
 
     @GetMapping("/{postId}")
@@ -44,7 +44,7 @@ public class PostController {
     public void updatePost(@PathVariable("postId") Long postId,
                            @RequestBody PostUpdateRequest request) {
 
-        postService.updatePost(postId, request.caption(), 1L);
+        postService.updatePost(postId, request.caption(), request.tags(), 1L);
     }
 
     // TODO : Security 적용

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostCreateRequest.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostCreateRequest.java
@@ -1,4 +1,4 @@
 package com.koreanbrains.onlinebutlerback.controller.post;
 
-public record PostCreateRequest(String caption) {
+public record PostCreateRequest(String caption, String[] tags) {
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostGetResponse.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostGetResponse.java
@@ -2,15 +2,22 @@ package com.koreanbrains.onlinebutlerback.controller.post;
 
 import com.koreanbrains.onlinebutlerback.entity.post.Post;
 import com.koreanbrains.onlinebutlerback.entity.post.PostImage;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
 
 import java.util.List;
 
-public record PostGetResponse(Long id, String caption, List<String> images) {
+public record PostGetResponse(Long id, String caption, List<String> images, List<String> tags) {
 
-    public PostGetResponse(Post post, List<PostImage> postImages) {
-        this(post.getId(), post.getCaption(), postImages.stream()
-                .map(PostImage::getUrl)
-                .toList());
+    public PostGetResponse(Post post, List<PostImage> postImages, List<Tag> tags) {
+        this(post.getId(),
+                post.getCaption(),
+                postImages.stream()
+                        .map(PostImage::getUrl)
+                        .toList(),
+                tags.stream()
+                        .map(Tag::getName)
+                        .toList()
+        );
     }
 
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostScrollRequest.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostScrollRequest.java
@@ -1,0 +1,4 @@
+package com.koreanbrains.onlinebutlerback.controller.post;
+
+public record PostScrollRequest(Long cursor, String tagName, int size) {
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostUpdateRequest.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/post/PostUpdateRequest.java
@@ -1,4 +1,4 @@
 package com.koreanbrains.onlinebutlerback.controller.post;
 
-public record PostUpdateRequest(String caption) {
+public record PostUpdateRequest(String caption, String[] tags) {
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/tag/TagController.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/tag/TagController.java
@@ -1,0 +1,24 @@
+package com.koreanbrains.onlinebutlerback.controller.tag;
+
+import com.koreanbrains.onlinebutlerback.common.scroll.Scroll;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tag")
+public class TagController {
+
+    private final TagQueryRepository tagQueryRepository;
+
+    @GetMapping
+    public Scroll<TagDto> searchTag(@ModelAttribute TagSearchRequest request) {
+        Scroll<Tag> tags = tagQueryRepository.searchTag(request.cursor(), request.tag(), request.size());
+        return tags.map(TagDto::new);
+    }
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/tag/TagDto.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/tag/TagDto.java
@@ -1,0 +1,9 @@
+package com.koreanbrains.onlinebutlerback.controller.tag;
+
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+
+public record TagDto(Long id, String name) {
+    public TagDto(Tag tag) {
+        this(tag.getId(), tag.getName());
+    }
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/controller/tag/TagSearchRequest.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/controller/tag/TagSearchRequest.java
@@ -1,0 +1,4 @@
+package com.koreanbrains.onlinebutlerback.controller.tag;
+
+public record TagSearchRequest(Long cursor, String tag, int size) {
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/entity/tag/Tag.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/entity/tag/Tag.java
@@ -1,0 +1,18 @@
+package com.koreanbrains.onlinebutlerback.entity.tag;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Tag {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private String name;
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/entity/tag/TagMapping.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/entity/tag/TagMapping.java
@@ -1,0 +1,22 @@
+package com.koreanbrains.onlinebutlerback.entity.tag;
+
+import com.koreanbrains.onlinebutlerback.entity.post.Post;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TagMapping {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Tag tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/post/PostQueryRepository.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/post/PostQueryRepository.java
@@ -1,0 +1,61 @@
+package com.koreanbrains.onlinebutlerback.repository.post;
+
+import com.koreanbrains.onlinebutlerback.common.scroll.Scroll;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.koreanbrains.onlinebutlerback.entity.post.QPost.*;
+import static com.koreanbrains.onlinebutlerback.entity.tag.QTag.*;
+import static com.koreanbrains.onlinebutlerback.entity.tag.QTagMapping.*;
+
+@Repository
+public class PostQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public PostQueryRepository(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(JPQLTemplates.DEFAULT, em);
+    }
+
+    public Scroll<PostScrollDto> scrollPost(Long cursor, String tagName, int size) {
+        List<PostScrollDto> posts = queryFactory
+                .from(post)
+                .leftJoin(tagMapping).on(tagMapping.post.id.eq(post.id))
+                .leftJoin(tag).on(tag.id.eq(tagMapping.tag.id))
+                .where(postIdLoe(cursor), tagNameEq(tagName))
+                .orderBy(post.id.desc())
+                .limit(size + 1)
+                .transform(GroupBy.groupBy(post.id).list(
+                        Projections.constructor(PostScrollDto.class,
+                                post.id,
+                                post.caption,
+                                GroupBy.list(
+                                        tag.name
+                                )
+                        )
+                ));
+
+        Long nextCursor = null;
+        if(posts.size() > size) {
+            nextCursor = posts.get(posts.size() - 1).id();
+            posts.remove(posts.size() - 1);
+        }
+
+        return new Scroll<>(posts, nextCursor, null);
+    }
+
+    private BooleanExpression postIdLoe(Long id) {
+        return id == null ? null : post.id.loe(id);
+    }
+
+    private BooleanExpression tagNameEq(String tagName) {
+        return StringUtils.hasText(tagName) ? tag.name.eq(tagName) : null;
+    }
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/post/PostScrollDto.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/post/PostScrollDto.java
@@ -1,6 +1,22 @@
 package com.koreanbrains.onlinebutlerback.repository.post;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
 import java.util.List;
 
-public record PostScrollDto(Long id, String caption, List<String> tags) {
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostScrollDto {
+
+    private Long id;
+    private String caption;
+    private List<String> tags = new ArrayList<>();
+
+    public void addTag(String tag) {
+        this.tags.add(tag);
+    }
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/post/PostScrollDto.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/post/PostScrollDto.java
@@ -1,0 +1,6 @@
+package com.koreanbrains.onlinebutlerback.repository.post;
+
+import java.util.List;
+
+public record PostScrollDto(Long id, String caption, List<String> tags) {
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagMappingRepository.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagMappingRepository.java
@@ -1,0 +1,14 @@
+package com.koreanbrains.onlinebutlerback.repository.tag;
+
+import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TagMappingRepository extends JpaRepository<TagMapping, Long> {
+
+    @Modifying
+    @Query("delete from TagMapping tm where tm.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagMappingRepository.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagMappingRepository.java
@@ -1,14 +1,19 @@
 package com.koreanbrains.onlinebutlerback.repository.tag;
 
+import com.koreanbrains.onlinebutlerback.entity.post.Post;
 import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface TagMappingRepository extends JpaRepository<TagMapping, Long> {
 
     @Modifying
     @Query("delete from TagMapping tm where tm.post.id = :postId")
     void deleteAllByPostId(@Param("postId") Long postId);
+
+    List<TagMapping> findAllByPost(Post post);
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepository.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepository.java
@@ -1,0 +1,43 @@
+package com.koreanbrains.onlinebutlerback.repository.tag;
+
+import com.koreanbrains.onlinebutlerback.common.scroll.Scroll;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.koreanbrains.onlinebutlerback.entity.tag.QTag.*;
+
+@Repository
+public class TagQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public TagQueryRepository(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public Scroll<Tag> searchTag(Long cursor, String name, int size) {
+        List<Tag> tags = queryFactory.select(tag)
+                .from(tag)
+                .where(tag.name.contains(name),
+                        idGoe(cursor))
+                .limit(size + 1)
+                .fetch();
+
+        Long nextCursor = null;
+        if(tags.size() > size) {
+            nextCursor = tags.get(tags.size() - 1).getId();
+            tags.remove(tags.size() - 1);
+        }
+
+        return new Scroll<>(tags, nextCursor, null);
+    }
+
+    private BooleanExpression idGoe(Long id) {
+        return id == null ? null : tag.id.goe(id);
+    }
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepository.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepository.java
@@ -38,6 +38,6 @@ public class TagQueryRepository {
     }
 
     private BooleanExpression idGoe(Long id) {
-        return id == null ? null : tag.id.goe(id);
+        return id == null ? tag.id.goe(0) : tag.id.goe(id);
     }
 }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagRepository.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/repository/tag/TagRepository.java
@@ -1,0 +1,11 @@
+package com.koreanbrains.onlinebutlerback.repository.tag;
+
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/com/koreanbrains/onlinebutlerback/service/post/PostService.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/service/post/PostService.java
@@ -79,6 +79,7 @@ public class PostService {
                 s3Client.delete(postImage.getStoredName());
             }
             postImageRepository.deleteAll(postImages);
+            tagService.resetTags(post.getId());
             postRepository.delete(post);
         });
     }

--- a/src/main/java/com/koreanbrains/onlinebutlerback/service/post/PostService.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/service/post/PostService.java
@@ -9,6 +9,7 @@ import com.koreanbrains.onlinebutlerback.entity.post.Post;
 import com.koreanbrains.onlinebutlerback.entity.post.PostImage;
 import com.koreanbrains.onlinebutlerback.repository.post.PostImageRepository;
 import com.koreanbrains.onlinebutlerback.repository.post.PostRepository;
+import com.koreanbrains.onlinebutlerback.service.tag.TagService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,15 +26,17 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
+    private final TagService tagService;
     private final S3Client s3Client;
 
     @Transactional
-    public Long createPost(String caption, MultipartFile[] images) {
+    public Long createPost(String caption, MultipartFile[] images, String[] tags) {
         Post post = Post.builder()
                 .caption(caption)
                 .build();
-
         Long postId = postRepository.save(post).getId();
+
+        tagService.linkTags(post, tags);
 
         for (MultipartFile image : images) {
             UploadFile uploadFile = s3Client.upload(image, UUID.randomUUID().toString());
@@ -52,7 +55,7 @@ public class PostService {
     }
 
     @Transactional
-    public void updatePost(Long postId, String caption, Long memberId) {
+    public void updatePost(Long postId, String caption, String[] tags, Long memberId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
 
@@ -61,6 +64,8 @@ public class PostService {
         }
 
         post.changeCaption(caption);
+        tagService.resetTags(post.getId());
+        tagService.linkTags(post, tags);
     }
 
     @Transactional

--- a/src/main/java/com/koreanbrains/onlinebutlerback/service/tag/TagService.java
+++ b/src/main/java/com/koreanbrains/onlinebutlerback/service/tag/TagService.java
@@ -1,0 +1,39 @@
+package com.koreanbrains.onlinebutlerback.service.tag;
+
+
+import com.koreanbrains.onlinebutlerback.entity.post.Post;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagMappingRepository;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagService {
+
+    private final TagRepository tagRepository;
+    private final TagMappingRepository tagMappingRepository;
+
+    @Transactional
+    public void linkTags(Post post, String[] tagNames) {
+        for (String tagName : tagNames) {
+            Tag tag = tagRepository.findByName(tagName)
+                    .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+
+            tagMappingRepository.save(TagMapping.builder()
+                    .tag(tag)
+                    .post(post)
+                    .build());
+        }
+    }
+
+    @Transactional
+    public void resetTags(Long postId) {
+        tagMappingRepository.deleteAllByPostId(postId);
+    }
+}

--- a/src/test/java/com/koreanbrains/onlinebutlerback/common/fixtures/TagFixture.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/common/fixtures/TagFixture.java
@@ -2,6 +2,9 @@ package com.koreanbrains.onlinebutlerback.common.fixtures;
 
 import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TagFixture {
 
     public static Tag tag() {
@@ -9,5 +12,17 @@ public class TagFixture {
                 .id(1L)
                 .name("태그")
                 .build();
+    }
+
+    public static List<Tag> tags(String... names) {
+        List<Tag> tags = new ArrayList<>();
+        for (int i = 0; i < names.length; i++) {
+            tags.add(Tag.builder()
+                    .id((long) i + 1)
+                    .name(names[i])
+                    .build());
+        }
+
+        return tags;
     }
 }

--- a/src/test/java/com/koreanbrains/onlinebutlerback/common/fixtures/TagFixture.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/common/fixtures/TagFixture.java
@@ -1,0 +1,13 @@
+package com.koreanbrains.onlinebutlerback.common.fixtures;
+
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+
+public class TagFixture {
+
+    public static Tag tag() {
+        return Tag.builder()
+                .id(1L)
+                .name("태그")
+                .build();
+    }
+}

--- a/src/test/java/com/koreanbrains/onlinebutlerback/common/fixtures/TagMappingFixture.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/common/fixtures/TagMappingFixture.java
@@ -1,0 +1,16 @@
+package com.koreanbrains.onlinebutlerback.common.fixtures;
+
+import com.koreanbrains.onlinebutlerback.entity.post.Post;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
+
+public class TagMappingFixture {
+
+    public static TagMapping tagMapping(Post post, Tag tag) {
+        return TagMapping.builder()
+                .id(1L)
+                .post(post)
+                .tag(tag)
+                .build();
+    }
+}

--- a/src/test/java/com/koreanbrains/onlinebutlerback/controller/post/PostControllerTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/controller/post/PostControllerTest.java
@@ -45,8 +45,8 @@ class PostControllerTest {
     @DisplayName("포스트를 생성한다")
     void createPost() throws Exception {
         // given
-        given(postService.createPost(any(), any())).willReturn(1L);
-        PostCreateRequest request = new PostCreateRequest("포스트 내용");
+        given(postService.createPost(any(), any(), any())).willReturn(1L);
+        PostCreateRequest request = new PostCreateRequest("포스트 내용", new String[]{"뚱냥이", "고양이"});
         MockMultipartFile post = new MockMultipartFile("post",
                 "post.json",
                 MediaType.APPLICATION_JSON_VALUE,
@@ -109,8 +109,8 @@ class PostControllerTest {
     @DisplayName("포스트 내용을 수정한다")
     void updatePost() throws Exception {
         // given
-        doNothing().when(postService).updatePost(anyLong(), anyString(), anyLong());
-        PostUpdateRequest request = new PostUpdateRequest("수정된 포스트 내용");
+        doNothing().when(postService).updatePost(anyLong(), anyString(), any(), anyLong());
+        PostUpdateRequest request = new PostUpdateRequest("수정된 포스트 내용", new String[]{"뚱냥이", "고양이"});
 
         // when
         ResultActions result = mockMvc.perform(patch("/post/{postId}", 1)

--- a/src/test/java/com/koreanbrains/onlinebutlerback/controller/post/PostControllerTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/controller/post/PostControllerTest.java
@@ -3,10 +3,15 @@ package com.koreanbrains.onlinebutlerback.controller.post;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.koreanbrains.onlinebutlerback.common.fixtures.PostFixture;
 import com.koreanbrains.onlinebutlerback.common.fixtures.PostImageFixture;
+import com.koreanbrains.onlinebutlerback.common.fixtures.TagFixture;
+import com.koreanbrains.onlinebutlerback.common.fixtures.TagMappingFixture;
 import com.koreanbrains.onlinebutlerback.entity.post.Post;
 import com.koreanbrains.onlinebutlerback.entity.post.PostImage;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
 import com.koreanbrains.onlinebutlerback.repository.post.PostImageRepository;
 import com.koreanbrains.onlinebutlerback.repository.post.PostRepository;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagMappingRepository;
 import com.koreanbrains.onlinebutlerback.service.post.PostService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +42,8 @@ class PostControllerTest {
     PostRepository postRepository;
     @MockBean
     PostImageRepository postImageRepository;
+    @MockBean
+    TagMappingRepository tagMappingRepository;
     @Autowired
     MockMvc mockMvc;
     ObjectMapper objectMapper = new ObjectMapper();
@@ -76,8 +83,11 @@ class PostControllerTest {
                 PostImageFixture.postImage(2L, post),
                 PostImageFixture.postImage(3L, post)
         );
+        Tag tag = TagFixture.tag();
+        TagMapping tagMapping = TagMappingFixture.tagMapping(post, tag);
         given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
         given(postImageRepository.findByPostId(anyLong())).willReturn(postImages);
+        given(tagMappingRepository.findAllByPost(any())).willReturn(List.of(tagMapping));
 
 
         // when
@@ -89,7 +99,8 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.caption").value(post.getCaption()))
                 .andExpect(jsonPath("$.images[0]").value(postImages.get(0).getUrl()))
                 .andExpect(jsonPath("$.images[1]").value(postImages.get(1).getUrl()))
-                .andExpect(jsonPath("$.images[2]").value(postImages.get(2).getUrl()));
+                .andExpect(jsonPath("$.images[2]").value(postImages.get(2).getUrl()))
+                .andExpect(jsonPath("$.tags[0]").value(tag.getName()));
     }
 
     @Test

--- a/src/test/java/com/koreanbrains/onlinebutlerback/controller/tag/TagControllerTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/controller/tag/TagControllerTest.java
@@ -1,0 +1,61 @@
+package com.koreanbrains.onlinebutlerback.controller.tag;
+
+import com.koreanbrains.onlinebutlerback.common.fixtures.TagFixture;
+import com.koreanbrains.onlinebutlerback.common.scroll.Scroll;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(controllers = TagController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class TagControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    TagQueryRepository tagQueryRepository;
+
+    @Test
+    @DisplayName("태그를 검색한다")
+    void searchTag() throws Exception {
+        // given
+        List<Tag> tags = TagFixture.tags("태그1", "태그2", "태그3", "태그4", "태그5");
+        Scroll<Tag> tagScroll = new Scroll<>(tags, 6L, null);
+        given(tagQueryRepository.searchTag(anyLong(), anyString(), anyInt()))
+                .willReturn(tagScroll);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/tag")
+                .param("cursor", "0")
+                .param("tag", "태그")
+                .param("size", "5"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.nextCursor").value(6))
+                .andExpect(jsonPath("$.content.length()").value(5))
+                .andExpect(jsonPath("$.content[0].name").value("태그1"))
+                .andExpect(jsonPath("$.content[1].name").value("태그2"))
+                .andExpect(jsonPath("$.content[2].name").value("태그3"))
+                .andExpect(jsonPath("$.content[3].name").value("태그4"))
+                .andExpect(jsonPath("$.content[4].name").value("태그5"));
+    }
+
+
+
+}

--- a/src/test/java/com/koreanbrains/onlinebutlerback/repository/post/PostQueryRepositoryTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/repository/post/PostQueryRepositoryTest.java
@@ -1,0 +1,138 @@
+package com.koreanbrains.onlinebutlerback.repository.post;
+
+import com.koreanbrains.onlinebutlerback.common.scroll.Scroll;
+import com.koreanbrains.onlinebutlerback.entity.post.Post;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagMappingRepository;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+class PostQueryRepositoryTest {
+
+    @Autowired
+    PostQueryRepository postQueryRepository;
+
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    TagRepository tagRepository;
+    @Autowired
+    TagMappingRepository tagMappingRepository;
+
+    @BeforeEach
+    void setup() {
+        List<Tag> tags = tagRepository.saveAll(List.of(
+                Tag.builder().name("태그 1").build(),
+                Tag.builder().name("태그 2").build()
+        ));
+
+        List<Post> posts = postRepository.saveAll(List.of(
+                Post.builder().caption("포스트 1").memberId(1L).build(),
+                Post.builder().caption("포스트 2").memberId(1L).build(),
+                Post.builder().caption("포스트 3").memberId(1L).build(),
+                Post.builder().caption("포스트 4").memberId(1L).build(),
+                Post.builder().caption("포스트 5").memberId(1L).build(),
+                Post.builder().caption("포스트 6").memberId(1L).build(),
+                Post.builder().caption("포스트 7").memberId(1L).build(),
+                Post.builder().caption("포스트 8").memberId(1L).build(),
+                Post.builder().caption("포스트 9").memberId(1L).build(),
+                Post.builder().caption("포스트 10").memberId(1L).build()
+        ));
+
+        for (Post post : posts) {
+            for (Tag tag : tags) {
+                tagMappingRepository.save(TagMapping.builder().tag(tag).post(post).build());
+            }
+        }
+    }
+
+
+    @Test
+    @DisplayName("포스트 목록을 무한스크롤로 조회한다")
+    void scrollPost() {
+        // given
+        Long cursor = null;
+        String tagName = null;
+        int size = 5;
+
+        // when
+        Scroll<PostScrollDto> result = postQueryRepository.scrollPost(cursor, tagName, size);
+
+        // then
+        assertThat(result.getNextCursor()).isEqualTo(5L);
+        assertThat(result.getNextSubCursor()).isNull();
+        assertThat(result.getContent().size()).isEqualTo(size);
+        assertThat(result.getContent().get(0).getCaption()).isEqualTo("포스트 10");
+        assertThat(result.getContent().get(1).getCaption()).isEqualTo("포스트 9");
+        assertThat(result.getContent().get(2).getCaption()).isEqualTo("포스트 8");
+        assertThat(result.getContent().get(3).getCaption()).isEqualTo("포스트 7");
+        assertThat(result.getContent().get(4).getCaption()).isEqualTo("포스트 6");
+    }
+
+    @Test
+    @DisplayName("포스트 목록 무한스크롤의 마지막 페이지를 조회한다")
+    void scrollPostLastPage() {
+        // given
+        Long cursor = 5L;
+        String tagName = null;
+        int size = 5;
+
+        // when
+        Scroll<PostScrollDto> result = postQueryRepository.scrollPost(cursor, tagName, size);
+
+        // then
+        assertThat(result.getNextCursor()).isNull();
+        assertThat(result.getNextSubCursor()).isNull();
+        assertThat(result.getContent().size()).isEqualTo(size);
+        assertThat(result.getContent().get(0).getCaption()).isEqualTo("포스트 5");
+        assertThat(result.getContent().get(1).getCaption()).isEqualTo("포스트 4");
+        assertThat(result.getContent().get(2).getCaption()).isEqualTo("포스트 3");
+        assertThat(result.getContent().get(3).getCaption()).isEqualTo("포스트 2");
+        assertThat(result.getContent().get(4).getCaption()).isEqualTo("포스트 1");
+    }
+
+    @Test
+    @DisplayName("특정 해시태그가 있는 포스트 목록을 무한스크롤로 조회한다")
+    void scrollPostTag() {
+        // given
+        Long cursor = null;
+        String tagName = "태그 1";
+        int size = 5;
+
+        // when
+        Scroll<PostScrollDto> result = postQueryRepository.scrollPost(cursor, tagName, size);
+
+        // then
+        assertThat(result.getNextCursor()).isEqualTo(5L);
+        assertThat(result.getNextSubCursor()).isNull();
+        assertThat(result.getContent().size()).isEqualTo(size);
+        assertThat(result.getContent().get(0).getCaption()).isEqualTo("포스트 10");
+        assertThat(result.getContent().get(1).getCaption()).isEqualTo("포스트 9");
+        assertThat(result.getContent().get(2).getCaption()).isEqualTo("포스트 8");
+        assertThat(result.getContent().get(3).getCaption()).isEqualTo("포스트 7");
+        assertThat(result.getContent().get(4).getCaption()).isEqualTo("포스트 6");
+    }
+
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        public PostQueryRepository postQueryRepository(EntityManager em) {
+            return new PostQueryRepository(em);
+        }
+    }
+
+}

--- a/src/test/java/com/koreanbrains/onlinebutlerback/repository/post/PostQueryRepositoryTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/repository/post/PostQueryRepositoryTest.java
@@ -31,9 +31,13 @@ class PostQueryRepositoryTest {
     TagRepository tagRepository;
     @Autowired
     TagMappingRepository tagMappingRepository;
+    @Autowired
+    EntityManager em;
 
     @BeforeEach
     void setup() {
+        em.createNativeQuery("ALTER TABLE post ALTER COLUMN id RESTART with 1").executeUpdate();
+
         List<Tag> tags = tagRepository.saveAll(List.of(
                 Tag.builder().name("태그 1").build(),
                 Tag.builder().name("태그 2").build()

--- a/src/test/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepositoryTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepositoryTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
 
 @DataJpaTest
@@ -22,20 +24,31 @@ class TagQueryRepositoryTest {
     @Autowired
     TagRepository tagRepository;
 
+    @Autowired
+    EntityManager em;
+
     @BeforeEach
     void setup() {
-        for (int i = 0; i < 10; i++) {
-            tagRepository.save(Tag.builder()
-                    .name("태그 " + i)
-                    .build());
-        }
+        em.createNativeQuery("ALTER TABLE tag ALTER COLUMN id RESTART with 1").executeUpdate();
+        tagRepository.saveAll(List.of(
+                Tag.builder().name("태그 1").build(),
+                Tag.builder().name("태그 2").build(),
+                Tag.builder().name("태그 3").build(),
+                Tag.builder().name("태그 4").build(),
+                Tag.builder().name("태그 5").build(),
+                Tag.builder().name("태그 6").build(),
+                Tag.builder().name("태그 7").build(),
+                Tag.builder().name("태그 8").build(),
+                Tag.builder().name("태그 9").build(),
+                Tag.builder().name("태그 10").build()
+        ));
     }
-    
+
     @Test
     @DisplayName("태그를 검색한다")
     void searchTag() {
         // given
-        Long cursor = 0L;
+        Long cursor = null;
         String name = "태그";
         int size = 5;
         
@@ -45,6 +58,23 @@ class TagQueryRepositoryTest {
         // then
         assertThat(tagScroll.getContent().size()).isEqualTo(size);
         assertThat(tagScroll.getNextCursor()).isEqualTo(size + 1L);
+        assertThat(tagScroll.getNextSubCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("태그 검색 결과 무한스크롤의 마지막 페이지를 조회한다")
+    void searchTagLastPage() {
+        // given
+        Long cursor = 6L;
+        String name = "태그";
+        int size = 5;
+
+        // when
+        Scroll<Tag> tagScroll = tagQueryRepository.searchTag(cursor, name, size);
+
+        // then
+        assertThat(tagScroll.getContent().size()).isEqualTo(size);
+        assertThat(tagScroll.getNextCursor()).isNull();
         assertThat(tagScroll.getNextSubCursor()).isNull();
     }
 

--- a/src/test/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepositoryTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/repository/tag/TagQueryRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.koreanbrains.onlinebutlerback.repository.tag;
+
+import com.koreanbrains.onlinebutlerback.common.scroll.Scroll;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+class TagQueryRepositoryTest {
+
+    @Autowired
+    TagQueryRepository tagQueryRepository;
+
+    @Autowired
+    TagRepository tagRepository;
+
+    @BeforeEach
+    void setup() {
+        for (int i = 0; i < 10; i++) {
+            tagRepository.save(Tag.builder()
+                    .name("태그 " + i)
+                    .build());
+        }
+    }
+    
+    @Test
+    @DisplayName("태그를 검색한다")
+    void searchTag() {
+        // given
+        Long cursor = 0L;
+        String name = "태그";
+        int size = 5;
+        
+        // when
+        Scroll<Tag> tagScroll = tagQueryRepository.searchTag(cursor, name, size);
+
+        // then
+        assertThat(tagScroll.getContent().size()).isEqualTo(size);
+        assertThat(tagScroll.getNextCursor()).isEqualTo(size + 1L);
+        assertThat(tagScroll.getNextSubCursor()).isNull();
+    }
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        public TagQueryRepository tagQueryRepository(EntityManager em) {
+            return new TagQueryRepository(em);
+        }
+    }
+}

--- a/src/test/java/com/koreanbrains/onlinebutlerback/service/post/PostServiceTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/service/post/PostServiceTest.java
@@ -11,6 +11,7 @@ import com.koreanbrains.onlinebutlerback.entity.post.Post;
 import com.koreanbrains.onlinebutlerback.entity.post.PostImage;
 import com.koreanbrains.onlinebutlerback.repository.post.PostImageRepository;
 import com.koreanbrains.onlinebutlerback.repository.post.PostRepository;
+import com.koreanbrains.onlinebutlerback.service.tag.TagService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +40,8 @@ class PostServiceTest {
     PostRepository postRepository;
     @Mock
     PostImageRepository postImageRepository;
+    @Mock
+    TagService tagService;
 
 
     @Test
@@ -55,12 +58,14 @@ class PostServiceTest {
                         "cat.jpg",
                         MediaType.IMAGE_PNG_VALUE,
                         "<<image>>".getBytes())};
+        String[] tags = {"고양이", "뚱냥이"};
 
         given(postRepository.save(any())).willReturn(Post.builder().id(1L).build());
         given(postImageRepository.save(any())).willReturn(PostImage.builder().build());
+        doNothing().when(tagService).linkTags(any(), any());
 
         // when
-        Long postId = postService.createPost(caption, images);
+        Long postId = postService.createPost(caption, images, tags);
 
         // then
         assertThat(postId).isEqualTo(1L);
@@ -79,10 +84,11 @@ class PostServiceTest {
                         "cat.jpg",
                         MediaType.IMAGE_PNG_VALUE,
                         "<<image>>".getBytes())};
+        String[] tags = {"고양이", "뚱냥이"};
         
         // when
         // then
-        assertThatThrownBy(() -> postService.createPost(caption, images))
+        assertThatThrownBy(() -> postService.createPost(caption, images, tags))
                 .isInstanceOf(IOException.class);
     }
 
@@ -94,7 +100,7 @@ class PostServiceTest {
         given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
 
         // when
-        postService.updatePost(1L, "수정된 포스트 내용", 1L);
+        postService.updatePost(1L, "수정된 포스트 내용", new String[]{"뚱냥이", "고양이"}, 1L);
 
         // then
         assertThat(post.getCaption()).isEqualTo("수정된 포스트 내용");
@@ -108,7 +114,7 @@ class PostServiceTest {
 
         // when
         // then
-        assertThatThrownBy(() -> postService.updatePost(1L, "수정된 포스트 내용", 1L))
+        assertThatThrownBy(() -> postService.updatePost(1L, "수정된 포스트 내용", new String[]{"뚱냥이", "고양이"}, 1L))
                 .isInstanceOf(EntityNotFoundException.class);
     }
 
@@ -121,7 +127,7 @@ class PostServiceTest {
 
         // when
         // then
-        assertThatThrownBy(() -> postService.updatePost(1L, "수정된 포스트 내용", 2L))
+        assertThatThrownBy(() -> postService.updatePost(1L, "수정된 포스트 내용", new String[]{"뚱냥이", "고양이"}, 2L))
                 .isInstanceOf(PermissionDeniedException.class);
     }
 

--- a/src/test/java/com/koreanbrains/onlinebutlerback/service/tag/TagServiceTest.java
+++ b/src/test/java/com/koreanbrains/onlinebutlerback/service/tag/TagServiceTest.java
@@ -1,0 +1,88 @@
+package com.koreanbrains.onlinebutlerback.service.tag;
+
+import com.koreanbrains.onlinebutlerback.common.fixtures.PostFixture;
+import com.koreanbrains.onlinebutlerback.common.fixtures.TagFixture;
+import com.koreanbrains.onlinebutlerback.common.fixtures.TagMappingFixture;
+import com.koreanbrains.onlinebutlerback.entity.post.Post;
+import com.koreanbrains.onlinebutlerback.entity.tag.Tag;
+import com.koreanbrains.onlinebutlerback.entity.tag.TagMapping;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagMappingRepository;
+import com.koreanbrains.onlinebutlerback.repository.tag.TagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TagServiceTest {
+
+    @InjectMocks
+    TagService tagService;
+
+    @Mock
+    TagRepository tagRepository;
+
+    @Mock
+    TagMappingRepository tagMappingRepository;
+
+    @Test
+    @DisplayName("태그와 포스트를 연결한다")
+    void linkTag() {
+        // given
+        Post post = PostFixture.post();
+        Tag tag = TagFixture.tag();
+        TagMapping tagMapping = TagMappingFixture.tagMapping(post, tag);
+        String[] tags = {"고양이", "뚱냥이"};
+
+        given(tagRepository.findByName(anyString())).willReturn(Optional.of(tag));
+        given(tagMappingRepository.save(any())).willReturn(tagMapping);
+
+        // when
+        tagService.linkTags(post, tags);
+
+        // then
+        then(tagRepository).should(times(2)).findByName(anyString());
+        then(tagMappingRepository).should(times(2)).save(any());
+    }
+
+    @Test
+    @DisplayName("태그와 포스트를 연결할 때 태그가 없으면 자동으로 생성된다")
+    void linkTagCreateTag() {
+        // given
+        Post post = PostFixture.post();
+        Tag tag = TagFixture.tag();
+        TagMapping tagMapping = TagMappingFixture.tagMapping(post, tag);
+        String[] tags = {"고양이", "뚱냥이"};
+
+        given(tagRepository.findByName(anyString())).willReturn(Optional.empty());
+        given(tagRepository.save(any())).willReturn(tag);
+        given(tagMappingRepository.save(any())).willReturn(tagMapping);
+
+        // when
+        tagService.linkTags(post, tags);
+
+        // then
+        then(tagRepository).should(times(2)).save(any());
+    }
+
+    @Test
+    @DisplayName("포스트에 연결된 태그를 초기화한다")
+    void resetTags() {
+        // given
+        Post post = PostFixture.post();
+        doNothing().when(tagMappingRepository).deleteAllByPostId(anyLong());
+
+        // when
+        tagService.resetTags(post.getId());
+
+        // then
+        then(tagMappingRepository).should().deleteAllByPostId(post.getId());
+    }
+
+}


### PR DESCRIPTION
- 해시태그 기능 추가
  -  포스트에 해시태그 적용시 새로운 태그면 태그 자동 생성
  -  `Tag` <-(1:N)-> `TagMapping` <-(N:1)-> `Post` 연관관계 구성
- 태그 검색 기능 추가 (무한스크롤)
- Post 목록 조회 태그 필터링 기능 추가 (무한스크롤)

Close #5